### PR TITLE
Output backtrace of errors.

### DIFF
--- a/roswell/lake.ros
+++ b/roswell/lake.ros
@@ -23,31 +23,27 @@ exec ros -m lake -Q -- $0 "$@"
 
 (defun main (&rest argv)
   (declare (ignorable argv))
-  (handler-case
-      (let (targets pathname jobs f-mode j-mode v-mode)
-        (loop for arg in argv
-           do (cond
-                (f-mode (setf pathname arg)
-                        (setf f-mode nil))
-                (j-mode (setf jobs (parse-integer arg))
-                        (setf j-mode nil))
-                ((string= "-f" arg) (setf f-mode t))
-                ((string= "-h" arg) (print-help)
-                                    (ros:quit 1))
-                ((string= "-j" arg) (setf j-mode t))
-                ((string= "-T" arg) (print-tasks pathname)
-                                    (ros:quit 1))
-                ((string= "-v" arg) (setf v-mode t))
-                (t (push arg targets))))
-        (let ((params `(:verbose ,v-mode
-                        ,@(when jobs
-                            `(:jobs ,jobs))
-                        ,@(when pathname
-                            `(:pathname ,pathname)))))
-          (if targets
-              (loop for target in (nreverse targets)
-                 do (apply #'lake:lake :target target params))
-              (apply #'lake:lake params))))
-    (error (e)
-      (format t "~A~%" e)
-      (ros:quit -1))))
+  (let (targets pathname jobs f-mode j-mode v-mode)
+    (loop for arg in argv
+          do (cond
+               (f-mode (setf pathname arg)
+                       (setf f-mode nil))
+               (j-mode (setf jobs (parse-integer arg))
+                       (setf j-mode nil))
+               ((string= "-f" arg) (setf f-mode t))
+               ((string= "-h" arg) (print-help)
+                (ros:quit 1))
+               ((string= "-j" arg) (setf j-mode t))
+               ((string= "-T" arg) (print-tasks pathname)
+                (ros:quit 1))
+               ((string= "-v" arg) (setf v-mode t))
+               (t (push arg targets))))
+    (let ((params `(:verbose ,v-mode
+                             ,@(when jobs
+                                 `(:jobs ,jobs))
+                             ,@(when pathname
+                                 `(:pathname ,pathname)))))
+      (if targets
+          (loop for target in (nreverse targets)
+                do (apply #'lake:lake :target target params))
+          (apply #'lake:lake params)))))


### PR DESCRIPTION
I think it's inconvenient that lake.ros doesn't show backtraces.

This patch just deletes `handler-case` around the main function.