### PR TITLE
Make output and error-output non-buffered.

### DIFF
--- a/src/lake.lisp
+++ b/src/lake.lisp
@@ -360,8 +360,8 @@
     (echo command))
   (multiple-value-bind (output error-output return-status)
       (run-program command :input :interactive
-                           :output t
-                           :error-output t
+                           :output :interactive
+                           :error-output :interactive
                            :ignore-error-status t)
     (declare (ignore output error-output))
     (unless (zerop return-status)


### PR DESCRIPTION
This fixes issue #82.

Now Lake will show subprocess' progress instead of keeping it in a buffer.

I also made a small repository with files to check if lake is working in an unbuffered mode:

https://github.com/svetlyak40wt/lake-test