### PR TITLE
Fixed installation from the GitHub, using Roswell

### DIFF
--- a/lake-cli.asd
+++ b/lake-cli.asd
@@ -1,0 +1,16 @@
+#|
+  This file is a part of lake project.
+  Copyright (c) 2015 Rudolph Miller (chopsticks.tk.ppfm@gmail.com)
+|#
+
+(defsystem "lake-cli"
+  :version "0.1.3"
+  :author "Rudolph Miller and Masayuki Takagi"
+  :license "MIT"
+  :homepage "https://github.com/takagi/lake"
+  :depends-on ("lake")
+  :description "Lake is a GNU make like build utility in Common Lisp."
+  :defsystem-depends-on (:deploy)
+  :build-operation "deploy-op"
+  :build-pathname "lake"
+  :entry-point "lake/main:uiop-main")

--- a/lake.asd
+++ b/lake.asd
@@ -19,10 +19,6 @@
                "lake/main"
                "lake/user")
   :description "Lake is a GNU make like build utility in Common Lisp."
-  ;; :defsystem-depends-on (:deploy)
-  ;; :build-operation "deploy-op"
-  ;; :build-pathname "lake"
-  :entry-point "lake/main:uiop-main"
   :long-description
   #.(with-open-file (stream (merge-pathnames
                              #p"README.md"

--- a/lake.asd
+++ b/lake.asd
@@ -19,9 +19,9 @@
                "lake/main"
                "lake/user")
   :description "Lake is a GNU make like build utility in Common Lisp."
-  :defsystem-depends-on (:deploy)
-  :build-operation "deploy-op"
-  :build-pathname "lake"
+  ;; :defsystem-depends-on (:deploy)
+  ;; :build-operation "deploy-op"
+  ;; :build-pathname "lake"
   :entry-point "lake/main:uiop-main"
   :long-description
   #.(with-open-file (stream (merge-pathnames


### PR DESCRIPTION
This fix moves dependency on `deploy` into a separate ASDF system which can be loaded only when we really want to call `ASDF:MAKE` to build the binary.

This pull should fix issue https://github.com/takagi/lake/issues/90